### PR TITLE
Use configured youtube folder for downloading

### DIFF
--- a/app/cyp.js
+++ b/app/cyp.js
@@ -1507,6 +1507,7 @@
       this.search.pending(true);
       let body = new URLSearchParams();
       body.set("id", id);
+      body.set("folder", escape(ytPath));
       let response = await fetch("youtube", { method: "POST", body });
       let reader = response.body.getReader();
       while (true) {

--- a/app/js/elements/yt.ts
+++ b/app/js/elements/yt.ts
@@ -59,6 +59,7 @@ class YT extends Component {
 
 		let body = new URLSearchParams();
 		body.set("id", id);
+		body.set("folder", escape(ytPath));
 		let response = await fetch("youtube", {method:"POST", body});
 
 		let reader = response.body!.getReader();


### PR DESCRIPTION
The download routine had the target folder hardcoded to "_youtube", not respecting the ytPath variable in conf.ts.

Fix this by propagating the configured folder to the downloader.

Limit it to a single, non-relative, folder for safety. Probably still not very secure, but as I know next to nothing about nodejs, I saw no other means to respect the ytPath variable.