### PR TITLE
fix: update Node.js base image from 16 to 20 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:20
 RUN apt update && apt install -y jq && apt clean
 RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl \
 	&& chmod a+rx /usr/local/bin/youtube-dl


### PR DESCRIPTION
## Summary

Fixes #35

This PR updates the Dockerfile to use Node.js 20 LTS instead of Node.js 16, which resolves the Docker image build failure.

## Problem

The automatic Docker image build was failing with:
```
ERROR: failed to solve: process "/bin/sh -c apt update && apt install -y jq && apt clean" did not complete successfully: exit code: 100
```

This occurred because Node.js 16 has reached end-of-life, and its underlying Debian repositories are no longer actively maintained, causing `apt update` to fail.

## Solution

Updated the base image from `node:16` to `node:20` (current LTS). Node 20 is actively supported and uses up-to-date Debian repositories, which resolves the build failure.

## Compatibility

The project's `package.json` specifies `"node": ">=10.0.0"`, so Node 20 is fully compatible.